### PR TITLE
Usage report customizations

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-var App = require("./lib/app").default;
+var App = require("./lib/app");
 
 module.exports = App;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-monthrange-picker-hydrationlabs",
-  "version": "1.9.0",
+  "version": "1.9.2",
   "description": "ReactJS Month range picker",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-monthrange-picker",
+  "name": "react-monthrange-picker-hydrationlabs",
   "version": "1.9.0",
   "description": "ReactJS Month range picker",
   "main": "index.js",
@@ -33,7 +33,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/munichlinux/react-monthrange-picker.git"
+    "url": "git+ssh://git@github.com:HydrationLabs/react-monthrange-picker.git"
   },
   "keywords": [
     "reactjs",
@@ -47,10 +47,11 @@
   "author": "Prashanth Iyer <munichlinux@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/munichlinux/react-monthrange-picker/issues"
+    "url": "https://github.com/HydrationLabs/react-monthrange-picker/issues"
   },
-  "homepage": "https://github.com/munichlinux/react-monthrange-picker#readme",
+  "homepage": "https://github.com/HydrationLabs/react-monthrange-picker#readme",
   "dependencies": {
+    "babel-loader": "^6.4.1",
     "jquery": "^3.1.1",
     "lodash": "^4.16.2",
     "moment": "^2.15.0",
@@ -61,7 +62,7 @@
   "devDependencies": {
     "babel": "^6.5.2",
     "babel-cli": "^6.16.0",
-    "babel-core": "^6.14.0",
+    "babel-core": "^6.26.0",
     "babel-preset-es2015": "^6.16.0",
     "babel-preset-react": "^6.16.0",
     "babelify": "^7.3.0",

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -114,4 +114,5 @@ App.defaultProps = {
   direction: 'bottom',
 };
 
-export default { App, Calendar };
+export default App;
+export { Calendar };

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -114,4 +114,4 @@ App.defaultProps = {
   direction: 'bottom',
 };
 
-export default App;
+export default { App, Calendar };

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -154,7 +154,7 @@ class Calendar extends React.Component {
       <div ref={node => (this.node = node)} className={popOverClass} style={this.calStyle}>
         {this.props.static || <div className="arrow" style={this.arrowStyle} />}
         <div className="clearfix sec-wrap">
-          <div className="calendar col-xs-10" style={this.props.hideButtons ? { width: '100%', paddingRight: '0px' } : {}}>
+          <div className="calendar col-xs-10" style={this.props.hideButtons ? { width: '100%', paddingRight: '0px' } : null}>
             <div className="clearfix">
               <div className="col-xs-6 year-start year">
                 <YearStart

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -9,6 +9,14 @@ class Calendar extends React.Component {
     super(props);
     this.selectMonthFn = this.selectMonth.bind(this);
 
+    let positionWidth;
+
+    try {
+      positionWidth = props.position.width;
+    } catch (e) {
+      positionWidth = 700;
+    }
+
     let positionTop;
 
     try {
@@ -26,10 +34,10 @@ class Calendar extends React.Component {
     }
 
     this.calStyle = {
-      width: '700px',
+      width: `${positionWidth}px`,
       top: `${positionTop}px`,
       left: `${positionLeft}px`,
-      display: props.display ? 'block' : 'none',
+      display: props.display || props.static ? 'block' : 'none',
     };
 
     this.arrowStyle = {};
@@ -75,13 +83,13 @@ class Calendar extends React.Component {
 
     const calStyle = _.cloneDeep(this.calStyle);
     const arrowStyle = _.cloneDeep(this.arrowStyle);
-    const picker = this.$el.siblings('.picker');
+    const picker = $(this.el).siblings('.picker');
     const direction = this.props.direction;
     const adjustmentConstant = 10;
 
     const calDim = {
-      height: this.$el.height(),
-      width: this.$el.width(),
+      height: $(this.el).height(),
+      width: $(this.el).width(),
     };
 
     const pickerDim = {
@@ -118,6 +126,8 @@ class Calendar extends React.Component {
 
     calStyle.display = props.display ? 'block' : 'none';
 
+    Object.assign(calStyle, props.calStyle);
+
     this.calStyle = calStyle;
     this.arrowStyle = arrowStyle;
   }
@@ -142,9 +152,9 @@ class Calendar extends React.Component {
 
     return (
       <div ref={node => (this.node = node)} className={popOverClass} style={this.calStyle}>
-        <div className="arrow" style={this.arrowStyle} />
+        {this.props.static || <div className="arrow" style={this.arrowStyle} />}
         <div className="clearfix sec-wrap">
-          <div className="calendar col-xs-10">
+          <div className="calendar col-xs-10" style={this.props.static && { width: '100%', paddingRight: '0px' }}>
             <div className="clearfix">
               <div className="col-xs-6 year-start year">
                 <YearStart
@@ -166,6 +176,7 @@ class Calendar extends React.Component {
               </div>
             </div>
           </div>
+          {this.props.hideButtons ||
           <div className="shortcuts col-xs-2">
             <button
               onClick={this.props.onApply}
@@ -182,6 +193,7 @@ class Calendar extends React.Component {
             Cancel
             </button>
           </div>
+          }
         </div>
       </div>
     );
@@ -194,13 +206,16 @@ Calendar.propTypes = {
   direction: React.PropTypes.oneOf(['top', 'left', 'right', 'bottom']).isRequired,
   display: React.PropTypes.bool.isRequired,
   onSelect: React.PropTypes.func.isRequired,
-  onApply: React.PropTypes.func.isRequired,
-  onCancel: React.PropTypes.func.isRequired,
+  onApply: React.PropTypes.func,
+  onCancel: React.PropTypes.func,
   onYearChange: React.PropTypes.func,
   position: React.PropTypes.shape({
-    top: React.PropTypes.number,
-    left: React.PropTypes.number,
+    width: React.PropTypes.string,
+    top: React.PropTypes.string,
+    left: React.PropTypes.string,
   }),
+  static: React.PropTypes.bool,
+  hideButtons: React.PropTypes.bool,
 };
 
 export default Calendar;

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -154,7 +154,7 @@ class Calendar extends React.Component {
       <div ref={node => (this.node = node)} className={popOverClass} style={this.calStyle}>
         {this.props.static || <div className="arrow" style={this.arrowStyle} />}
         <div className="clearfix sec-wrap">
-          <div className="calendar col-xs-10" style={this.props.static && { width: '100%', paddingRight: '0px' }}>
+          <div className="calendar col-xs-10" style={this.props.hideButtons ? { width: '100%', paddingRight: '0px' } : {}}>
             <div className="clearfix">
               <div className="col-xs-6 year-start year">
                 <YearStart

--- a/src/css/sass/monthly_picker.scss
+++ b/src/css/sass/monthly_picker.scss
@@ -126,6 +126,14 @@
             color: #fff;
           }
         }
+
+        &.disabled {
+          background-color: lightgray;
+          
+          button {
+            color: gray;
+          }
+        }
       }
     }
   }

--- a/src/year.jsx
+++ b/src/year.jsx
@@ -65,6 +65,7 @@ class YearBase extends React.Component {
   render() {
     const currYear = this.state.currYear;
     const selectedRange = this.props.selectedDateRange;
+    const restrictionRange = this.props.restrictionRange;
     const newDate = new Date();
 
     newDate.setYear(currYear);
@@ -77,13 +78,16 @@ class YearBase extends React.Component {
       } else if (selectedRange.contains(newDate, true)) {
         selection = 'highlight';
       }
+      if (!restrictionRange.contains(newDate, false)) {
+        selection = 'disabled';
+      }
 
       return (
         <span key={Date.now() + idx} className={`${selection} month`}>
           <button
             className="cal-month btn btn-plain"
             data-idx={idx}
-            onClick={this.selectMonthFn}
+            onClick={selection === 'disabled' ? () => {} : this.selectMonthFn}
             data-month={month}
           >
             {month}


### PR DESCRIPTION
[EN-891](https://getbevi.atlassian.net/browse/EN-891) - Make Usage report available for partners

I exported the Calendar object and added some style customizations that let us have the calendar always visible, embedded in the page, with invalid months grayed out.